### PR TITLE
fix: crash when fetching balance

### DIFF
--- a/SatsBuddy/Service/BdkService.swift
+++ b/SatsBuddy/Service/BdkService.swift
@@ -49,13 +49,13 @@ private struct BdkService {
             let mempool_stats: MempoolStats
 
             struct ChainStats: Codable {
-                let funded_txo_sum: UInt64
-                let spent_txo_sum: UInt64
+                let funded_txo_sum: Int64
+                let spent_txo_sum: Int64
             }
 
             struct MempoolStats: Codable {
-                let funded_txo_sum: UInt64
-                let spent_txo_sum: UInt64
+                let funded_txo_sum: Int64
+                let spent_txo_sum: Int64
             }
         }
 
@@ -71,10 +71,10 @@ private struct BdkService {
         Log.cktap.debug(
             "Retrieved on-chain balance from Mempool.space: \(totalBalance, privacy: .private) sats"
         )
-
-        let confirmedAmount = Amount.fromSat(satoshi: confirmedBalance)
-        let mempoolAmount = Amount.fromSat(satoshi: mempoolBalance)
-        let totalAmount = Amount.fromSat(satoshi: totalBalance)
+        
+        let confirmedAmount = Amount.fromSat(satoshi: confirmedBalance.nonNegativeValue().toUInt64())
+        let mempoolAmount = Amount.fromSat(satoshi: mempoolBalance.nonNegativeValue().toUInt64())
+        let totalAmount = Amount.fromSat(satoshi: totalBalance.nonNegativeValue().toUInt64())
         let zero = Amount.fromSat(satoshi: 0)
 
         return Balance(

--- a/SatsBuddy/Utilities/Int+Extensions.swift
+++ b/SatsBuddy/Utilities/Int+Extensions.swift
@@ -52,3 +52,13 @@ extension UInt64 {
         return numberFormatter.string(from: NSNumber(value: self)) ?? "0"
     }
 }
+
+extension Int64 {
+    func nonNegativeValue() -> Int64 {
+        self < .zero ? self * -1 : self
+    }
+    
+    func toUInt64() -> UInt64 {
+        UInt64(truncatingIfNeeded: self)
+    }
+}


### PR DESCRIPTION
After sending a transaction, the mempool API returns negative values in some fields, causing a crash when converting to `UInt64`.

To solve this, the object now receives an `Int64` and the code handles it to avoid using negative values with UInt64.

### Problem evidence:
https://github.com/user-attachments/assets/a7f822dc-bfe1-44c1-b25d-a6cd29b83b08

### Solution evidence:
https://github.com/user-attachments/assets/99f3b663-1f7e-4b21-99a6-2afb310a967d


