### PR TITLE
Fix large font size issue and update readme for running locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,67 @@ Download on [TestFlight](https://testflight.apple.com/join/Pq7KwWzB).
 
 - [rust-cktap](https://github.com/notmandatory/rust-cktap)
 
+## Running SatsBuddy Locally
+
+### Prerequisites
+
+- Xcode (and Xcode Command Line Tools)
+- Git
+- Rust toolchain (via `rustup`) — required to build the CKTap Swift XCFramework
+
+You can verify the required tools are installed with:
+
+```bash
+xcodebuild -version
+git --version
+rustc --version
+cargo --version
+```
+
+### Repository Setup (Important Folder Layout)
+
+SatsBuddy depends on the rust-cktap repository via a local Swift Package reference.
+Both repositories must be cloned into the same parent directory.
+
+```bash
+cd ~/Documents
+git clone https://github.com/reez/SatsBuddy.git
+git clone https://github.com/bitcoindevkit/rust-cktap.git
+```
+
+Resulting folder structure:
+
+```bash
+~/Documents/
+├─ SatsBuddy/
+└─ rust-cktap/
+   └─ cktap-swift/
+```
+
+### Build the CKTap XCFramework
+
+The `rust-cktap/cktap-swift` package includes a script that builds the
+`cktapFFI.xcframework` required by Swift Package Manager.
+
+Run the following:
+
+```bash
+cd ~/Documents/rust-cktap/cktap-swift
+chmod +x build-xcframework.sh
+./build-xcframework.sh
+```
+
+## SwiftUI Previews
+
+This project links native / FFI-heavy dependencies (CKTap, BitcoinDevKit).
+On some Xcode versions, SwiftUI previews may crash using the default preview
+execution mode, even though the app runs correctly in the simulator.
+
+To fix this:
+From inside a SwiftUI View code file,
+Select Editor -> Canvas -> Enable “Use Legacy Previews Execution”
+After enabling this option, SwiftUI previews should render normally.
+
 ## About
 
 Made in Nashville.

--- a/SatsBuddy/View/ActiveSlotView.swift
+++ b/SatsBuddy/View/ActiveSlotView.swift
@@ -68,16 +68,20 @@ struct ActiveSlotView: View {
                             value: balanceFormat
                         )
 
-                    ProgressView()
-                        .scaleEffect(0.6)
-                        .frame(width: 20, height: 20)
-                        .opacity(isLoading ? 1 : 0)
-                        .accessibilityHidden(!isLoading)
-                    Spacer()
+                    if isLoading {
+                        ProgressView()
+                            .scaleEffect(0.6)
+                            .frame(width: 20, height: 20)
+                            .opacity(isLoading ? 1 : 0)
+                            .accessibilityHidden(!isLoading)
+                    }
                 }
                 .font(.largeTitle)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
                 .fontWeight(.bold)
                 .fontDesign(.rounded)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .padding()
                 .animation(.smooth, value: slot.balance)
                 .onTapGesture {

--- a/SatsBuddy/View/SatsCardListView.swift
+++ b/SatsBuddy/View/SatsCardListView.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import UIKit
 
 struct SatsCardListView: View {
     @State var viewModel: SatsCardViewModel
@@ -61,8 +60,6 @@ struct SatsCardListView: View {
                     }
                     .listStyle(.insetGrouped)
                 }
-
-                //                Spacer()
             }
             .navigationTitle("SatsBuddy".uppercased())
             .navigationBarTitleDisplayMode(.large)


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/reez/SatsBuddy/issues/78) that would cause the decimal number of bitcoin to break over to a second line when the user is using larger fonts on their device:

Example of the fix at the largest accessible font size:

<img width="318" height="697" alt="image" src="https://github.com/user-attachments/assets/76f66311-84b9-4f09-a655-4f24c8f07687" />

This PR also adds some instructions to the readme to help other users get up and running with the project more quickly

@reez got the first fix ready for review
