### PR TITLE
feat: show wallet sync state during send preflight

### DIFF
--- a/SatsBuddy/ViewModel/Send/SendSignViewModel.swift
+++ b/SatsBuddy/ViewModel/Send/SendSignViewModel.swift
@@ -23,6 +23,7 @@ final class SendSignViewModel: NSObject, @MainActor NFCTagReaderSessionDelegate 
     enum State {
         case idle
         case preparingPsbt
+        case syncingWallet
         case ready
         case tapping
         case unsealed
@@ -49,6 +50,7 @@ final class SendSignViewModel: NSObject, @MainActor NFCTagReaderSessionDelegate 
 
     private enum StatusPhase {
         case preparingSweep
+        case syncingWallet
         case readyToSignAndBroadcast
         case stillPreparing
         case enterCvc
@@ -75,6 +77,8 @@ final class SendSignViewModel: NSObject, @MainActor NFCTagReaderSessionDelegate 
             switch self {
             case .preparingSweep:
                 return "Preparing sweep transaction…"
+            case .syncingWallet:
+                return "Syncing wallet with the network…"
             case .readyToSignAndBroadcast:
                 return "Enter CVC, tap card to send transaction."
             case .stillPreparing:
@@ -170,7 +174,7 @@ final class SendSignViewModel: NSObject, @MainActor NFCTagReaderSessionDelegate 
     var state: State = .idle
     var isBusy: Bool {
         switch state {
-        case .preparingPsbt, .tapping:
+        case .preparingPsbt, .syncingWallet, .tapping:
             return true
         default:
             return false
@@ -251,6 +255,9 @@ final class SendSignViewModel: NSObject, @MainActor NFCTagReaderSessionDelegate 
                 return
             }
 
+            state = .syncingWallet
+            setStatusMessage(.syncingWallet)
+
             let preparedPsbt = try await bdkClient.buildPsbt(
                 sourceDescriptor,
                 address,
@@ -275,6 +282,8 @@ final class SendSignViewModel: NSObject, @MainActor NFCTagReaderSessionDelegate 
         guard case .ready = state else {
             if case .preparingPsbt = state {
                 setStatusMessage(.stillPreparing)
+            } else if case .syncingWallet = state {
+                setStatusMessage(.syncingWallet)
             }
             return
         }


### PR DESCRIPTION
### Motivation

Sometimes, when we enter the sweep balance flow, the app gets stuck in `.preparingPsbt`. What is actually happening is that the wallet is syncing its state. This looks like a bug to users because the preparing status can take a few minutes when wallet syncing. This happened to me.

### Changes

- Add a new `SendSignViewModel.State.syncingWallet` case to represent the wallet-sync phase distinctly from PSBT preparation.
- Add a matching `StatusPhase.syncingWallet` with the user-facing message `"Syncing wallet with the network…"`.
- Include `.syncingWallet` in `isBusy` so the Send button stays disabled and the spinner keeps running during sync.
- In `runPreflightIfNeeded()`, transition to `.syncingWallet` immediately before calling `bdkClient.buildPsbt(...)`, since `setupEsploraClientAndSync` runs inside it and dominates the wait.
- In `startNfc()`, if the user taps Send while syncing, re-emit the sync status message instead of falling through silently.

### problem
* I got stuck on this screen for a few minutes, then it synced.
<img width="590" height="1278" alt="Screenshot 2026-04-08 at 08 41 37" src="https://github.com/user-attachments/assets/7a2b70ea-8a30-4cd6-855a-b1a1c64f09cd" />


### Test plan

- [ ] Enter the sweep balance flow on a slot that requires a network sync and verify the status text changes from "Preparing sweep transaction…" to "Syncing wallet with the network…" while the sync runs.
- [ ] Verify the Send button stays disabled and shows the spinner during sync.
- [ ] Verify the flow transitions to "Enter CVC, tap card to send transaction." once sync completes and the PSBT is ready.
- [ ] Tap Send during the sync phase and confirm the sync status message is shown (no stale "Preparing" text).