### PR TITLE
fix: normalize exhausted final slot display state

### DIFF
--- a/SatsBuddy/Model/SatsCard.swift
+++ b/SatsBuddy/Model/SatsCard.swift
@@ -248,7 +248,27 @@ struct SatsCardInfo: Identifiable, Codable {
 
         // Some cards appear to leave the final consumed slot as "current" instead of
         // advancing `activeSlot` past `totalSlots`. Treat that terminal state as exhausted.
-        return isTerminalFinalSlot
+        return exhaustedTerminalSlotNumber != nil
+    }
+
+    var displaySlots: [SlotInfo] {
+        guard let exhaustedTerminalSlotNumber else { return slots }
+
+        return slots.map { slot in
+            guard slot.slotNumber == exhaustedTerminalSlotNumber else { return slot }
+
+            return SlotInfo(
+                id: slot.id,
+                slotNumber: slot.slotNumber,
+                isActive: false,
+                isUsed: true,
+                pubkey: slot.pubkey,
+                pubkeyDescriptor: slot.pubkeyDescriptor,
+                address: slot.address,
+                balance: slot.balance,
+                state: .historical
+            )
+        }
     }
 
     var displayActiveSlotNumber: Int? {
@@ -270,14 +290,15 @@ struct SatsCardInfo: Identifiable, Codable {
         return "\(totalSlots)/\(totalSlots)"
     }
 
-    private var isTerminalFinalSlot: Bool {
-        guard let activeSlot, let totalSlots, totalSlots > 0 else { return false }
-        guard activeSlot == totalSlots - 1 else { return false }
+    private var exhaustedTerminalSlotNumber: UInt8? {
+        guard let activeSlot, let totalSlots, totalSlots > 0 else { return nil }
+        guard activeSlot == totalSlots - 1 else { return nil }
         guard let currentSlot = slots.first(where: { $0.isActive && $0.slotNumber == activeSlot })
         else {
-            return false
+            return nil
         }
 
-        return currentSlot.isUsed && currentSlot.state == .activeNeedsSetup
+        guard currentSlot.isUsed && currentSlot.state == .activeNeedsSetup else { return nil }
+        return currentSlot.slotNumber
     }
 }

--- a/SatsBuddy/View/SatsCardDetailView.swift
+++ b/SatsBuddy/View/SatsCardDetailView.swift
@@ -407,7 +407,7 @@ extension SatsCardDetailView {
     private var exhaustedSlot: SlotInfo? {
         guard updatedCard.isExhausted else { return nil }
         return viewModel.slots.last(where: { $0.isUsed })
-            ?? updatedCard.slots.last(where: { $0.isUsed })
+            ?? updatedCard.displaySlots.last(where: { $0.isUsed })
     }
 
     private var slotForDisplay: SlotInfo {

--- a/SatsBuddy/View/SlotHistoryView.swift
+++ b/SatsBuddy/View/SlotHistoryView.swift
@@ -31,11 +31,14 @@ struct SlotHistoryView: View {
         card: SatsCardInfo,
         priceStore: PriceStore
     ) {
-        self.slot = slot
+        let displaySlot =
+            card.displaySlots.first(where: { $0.slotNumber == slot.slotNumber }) ?? slot
+
+        self.slot = displaySlot
         self.network = network
         self.card = card
         self.priceStore = priceStore
-        _slotDetails = State(initialValue: slot)
+        _slotDetails = State(initialValue: displaySlot)
         _viewModel = State(initialValue: viewModel)
     }
 
@@ -109,7 +112,7 @@ struct SlotHistoryView: View {
         }
         .navigationDestination(isPresented: $isShowingSend) {
             SendFlowView(
-                slot: slot,
+                slot: slotDetails,
                 card: card,
                 onBroadcastSuccess: { _ in
                     isRefreshingBalanceAfterBroadcast = true

--- a/SatsBuddy/ViewModel/SatsCardDetailViewModel.swift
+++ b/SatsBuddy/ViewModel/SatsCardDetailViewModel.swift
@@ -73,7 +73,7 @@ class SatsCardDetailViewModel {
         sweepBalanceDisabledMessage = nil
         sweepBalanceDisabledLinkURL = nil
 
-        slots = card.slots
+        slots = card.displaySlots
 
         balanceFetchTask?.cancel()
         let fetchToken = UUID()
@@ -205,12 +205,12 @@ class SatsCardDetailViewModel {
     }
 
     private func displayedSlot(for card: SatsCardInfo) -> SlotInfo? {
-        if let activeSlot = card.slots.first(where: { $0.isActive }) {
+        if let activeSlot = card.displaySlots.first(where: { $0.isActive }) {
             return activeSlot
         }
 
         guard card.isExhausted else { return nil }
-        return card.slots.last(where: { $0.isUsed })
+        return card.displaySlots.last(where: { $0.isUsed })
     }
 
     private func pendingConfirmationLinkURL(

--- a/SatsBuddyTests/ModelValueTests.swift
+++ b/SatsBuddyTests/ModelValueTests.swift
@@ -498,6 +498,55 @@ final class ModelValueTests: XCTestCase {
     }
 
     @MainActor
+    func testDetailViewModelNormalizesTerminalFinalSlotBeforeFetchingBalance() async {
+        let finalSlot = makeSlotInfo(
+            id: UUID(uuidString: "00000000-0000-0000-0000-000000000010")!,
+            slotNumber: 9,
+            isActive: true,
+            isUsed: true,
+            address: "bc1qfinalslot",
+            balance: nil,
+            state: .activeNeedsSetup
+        )
+        let card = makeSatsCard(
+            address: nil,
+            activeSlot: 9,
+            totalSlots: 10,
+            slots: [finalSlot]
+        )
+        let viewModel = SatsCardDetailViewModel(
+            bdkClient: BdkClient(
+                deriveAddress: { descriptor, _ in descriptor },
+                getBalanceFromAddress: { address, _ in
+                    XCTAssertEqual(address, "bc1qfinalslot")
+                    return Self.makeBalance(totalSats: 28_206, confirmedSats: 28_206)
+                },
+                warmUp: {},
+                getTransactionsForAddress: { _, _, _ in
+                    []
+                },
+                buildPsbt: { _, _, _, _ in
+                    throw TestError.expected("buildPsbt not used in this test")
+                },
+                broadcast: { _, _ in }
+            )
+        )
+
+        viewModel.loadSlotDetails(for: card)
+
+        await waitUntil {
+            !viewModel.isLoading
+        }
+
+        XCTAssertEqual(viewModel.slots.count, 1)
+        XCTAssertFalse(viewModel.slots[0].isActive)
+        XCTAssertEqual(viewModel.slots[0].state, .historical)
+        XCTAssertEqual(viewModel.slots[0].balance, 28_206)
+        XCTAssertFalse(viewModel.isSweepBalanceButtonDisabled)
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
     func testDetailViewModelApplyPostBroadcastWarningShowsWarningWhenNoOtherErrorExists() {
         let viewModel = SatsCardDetailViewModel()
 


### PR DESCRIPTION
This fixes a bug where an exhausted SATSCARD could show conflicting UI states, with the card saying “All slots used” while the final slot still appeared as CURRENT / UNUSED. The change normalizes that terminal final slot into a historical display state in the detail/history flow so exhausted cards render consistently and added a regression test for that case.